### PR TITLE
Notify on publishing non existing events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka core changelog
 
+# Unreleased
+- Disallow publishing events that were not registered.
+
 ## 2.0.3 (2022-10-13)
 - Maintenance release. Cert chain update. No code changes.
 

--- a/lib/karafka/core/monitoring/notifications.rb
+++ b/lib/karafka/core/monitoring/notifications.rb
@@ -27,7 +27,7 @@ module Karafka
 
         # Registers a new event on which we can publish
         #
-        # @param event_id [String, Symbol] event id
+        # @param event_id [String] event id
         def register_event(event_id)
           @listeners[event_id]
           @events_methods_map[event_id] = :"on_#{event_id.to_s.tr('.', '_')}"
@@ -73,7 +73,7 @@ module Karafka
         # Allows for code instrumentation
         # Runs the provided code and sends the instrumentation details to all registered listeners
         #
-        # @param event_id [String, Symbol] id of the event
+        # @param event_id [String] id of the event
         # @param payload [Hash] payload for the instrumentation
         # @param block [Proc] instrumented code
         # @return [Object] whatever the provided block (if any) returns
@@ -83,6 +83,9 @@ module Karafka
         #     sleep(1)
         #   end
         def instrument(event_id, payload = EMPTY_HASH, &block)
+          # Allow for instrumentation of only events we registered
+          raise EventNotRegistered, event_id unless @listeners.key?(event_id)
+
           result, time = measure_time_taken(&block) if block_given?
 
           event = Event.new(

--- a/spec/lib/karafka/core/monitoring/notifications_spec.rb
+++ b/spec/lib/karafka/core/monitoring/notifications_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe_current do
     it 'expect to return blocks execution value' do
       expect(instrumentation).to eq result
     end
+
+    context 'when we want to instrument event that was not registered' do
+      it 'expect to raise error' do
+        expected_error = Karafka::Core::Monitoring::Notifications::EventNotRegistered
+        expect { notifications.instrument('na') }.to raise_error(expected_error)
+      end
+    end
   end
 
   describe '#subscribe' do


### PR DESCRIPTION
This PR adds an exception when we want to publish on non existing events. This makes it easier to track typos and other mistakes.