### PR TITLE
Do not compile `Node` multiple times

### DIFF
--- a/lib/karafka/core/configurable/node.rb
+++ b/lib/karafka/core/configurable/node.rb
@@ -21,6 +21,7 @@ module Karafka
           @name = name
           @children = []
           @nestings = nestings
+          @compiled = false
           instance_eval(&nestings)
         end
 
@@ -43,7 +44,7 @@ module Karafka
         # Compile settings, allow for overrides via yielding
         # @return [Node] returns self after configuration
         def configure
-          compile
+          compile unless @compiled
           yield(self) if block_given?
           self
         end
@@ -97,6 +98,7 @@ module Karafka
 
             public_send("#{value.name}=", initialized)
           end
+          @compiled = true
         end
       end
     end


### PR DESCRIPTION
In `karafka`, for example, we're calling `configure` multiple times (https://github.com/karafka/karafka/blob/master/lib/karafka/setup/config.rb#L139 & https://github.com/karafka/karafka/blob/master/lib/karafka/setup/config.rb#L145), which leads to method redefinition warnings in `singleton_class.attr_accessor value.name`.

Not sure how/if this should be tested though, reopen the class after `configure`, add some setting, check that it didn't appeared? Also, is it fine that in this case we're not adding the setting and not warning the user anyhow about it?