### PR TITLE
extract time helper from karafka

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka core changelog
 
+## 2.0.8 (Unreleased)
+- Add `Karafka::Core::Helpers::Time` utility for time reporting.
+
 ## 2.0.7 (2022-12-18)
 - Allow for recompilation of config upon injecting new config nodes.
 - Compile given config scope automatically after it is defined.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka-core (2.0.7)
+    karafka-core (2.0.8)
       concurrent-ruby (>= 1.1)
       rdkafka (>= 0.12)
 

--- a/lib/karafka-core.rb
+++ b/lib/karafka-core.rb
@@ -11,6 +11,8 @@
   karafka/core
   karafka/core/version
 
+  karafka/core/helpers/time
+
   karafka/core/monitoring
   karafka/core/monitoring/event
   karafka/core/monitoring/monitor

--- a/lib/karafka/core/helpers/time.rb
+++ b/lib/karafka/core/helpers/time.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Karafka
+  module Core
+    # Namespace for some small utilities used across the ecosystem
+    module Helpers
+      # Time related methods used across Karafka
+      module Time
+        # @return [Float] current monotonic time in milliseconds
+        def monotonic_now
+          ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) * 1_000
+        end
+
+        # @return [Float] current time in float
+        def float_now
+          ::Time.now.utc.to_f
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/core/monitoring/notifications.rb
+++ b/lib/karafka/core/monitoring/notifications.rb
@@ -9,6 +9,8 @@ module Karafka
       # We do not use any of them by default as our use-case is fairly simple and we do not want
       # to have too many external dependencies.
       class Notifications
+        include Core::Helpers::Time
+
         attr_reader :name
 
         # Raised when someone wants to publish event that was not registered
@@ -112,14 +114,9 @@ module Karafka
         # Measures time taken to execute a given block and returns it together with the result of
         # the block execution
         def measure_time_taken
-          start = current_time
+          start = monotonic_now
           result = yield
-          [result, current_time - start]
-        end
-
-        # @return [Integer] current monotonic time
-        def current_time
-          ::Process.clock_gettime(::Process::CLOCK_MONOTONIC, :millisecond)
+          [result, monotonic_now - start]
         end
       end
     end

--- a/lib/karafka/core/version.rb
+++ b/lib/karafka/core/version.rb
@@ -4,6 +4,6 @@ module Karafka
   module Core
     # Current Karafka::Core version
     # We follow the versioning schema of given Karafka version
-    VERSION = '2.0.7'
+    VERSION = '2.0.8'
   end
 end

--- a/spec/lib/karafka/core/helpers/time_spec.rb
+++ b/spec/lib/karafka/core/helpers/time_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  let(:timed) do
+    current = described_class
+
+    Class.new do
+      extend current
+    end
+  end
+
+  describe '#monotonic_now' do
+    it 'expect to return monotonic in ms' do
+      pre = timed.monotonic_now
+      sleep(0.5)
+      expect(timed.monotonic_now - pre).to be_within(500).of(500)
+    end
+  end
+
+  describe '#float_now' do
+    it 'expect to return float time in ms' do
+      pre = timed.float_now
+      sleep(0.5)
+      expect(timed.float_now - pre).to be_within(500).of(500)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the time helper used separately in karafka and waterdrop and soon in the web.
