### PR TITLE
use beta2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Karafka core changelog
 
 ## 2.1.0 (Unreleased)
-- [Change] Set `karafka-rdkafka` requirement from `>= 0.13.0.beta1` to `<= 0.14.0`.
+- [Change] Set `karafka-rdkafka` requirement from `>= 0.13.0.beta2` to `<= 0.14.0`.
 - [Change] Remove no longer needed patch.
 
 ## 2.0.13 (2023-05-26)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     karafka-core (2.1.0)
       concurrent-ruby (>= 1.1)
-      karafka-rdkafka (>= 0.13.0.beta1, < 0.14.0)
+      karafka-rdkafka (>= 0.13.0.beta2, < 0.14.0)
 
 GEM
   remote: https://rubygems.org/
@@ -22,7 +22,7 @@ GEM
     ffi (1.15.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    karafka-rdkafka (0.13.0.beta1)
+    karafka-rdkafka (0.13.0.beta2)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)

--- a/karafka-core.gemspec
+++ b/karafka-core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.licenses    = %w[MIT]
 
   spec.add_dependency 'concurrent-ruby', '>= 1.1'
-  spec.add_dependency 'karafka-rdkafka', '>= 0.13.0.beta1', '< 0.14.0'
+  spec.add_dependency 'karafka-rdkafka', '>= 0.13.0.beta2', '< 0.14.0'
 
   spec.required_ruby_version = '>= 2.6.0'
 


### PR DESCRIPTION
This PR ensures, that we use at least beta2 of 0.13.0 because of the critical lock error.