### PR TITLE
introduce freeze duration and optimize objects allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Karafka core changelog
 
+## 2.2.1 (Unreleased)
+- Optimize statistics decorator by minimizing number of new objects created.
+- Expand the decoration to include new value `_fd` providing freeze duration in milliseconds. This value informs us for how many consecutive ms the given value did not change. It can be useful for detecting values that should change once in a while but are stale.
+
 ## 2.2.0 (2023-09-01)
 - [Maintenance] Update the signing cert (old expired)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka-core (2.2.0)
+    karafka-core (2.2.1)
       concurrent-ruby (>= 1.1)
       karafka-rdkafka (>= 0.13.1, < 0.14.0)
 

--- a/lib/karafka/core/monitoring/statistics_decorator.rb
+++ b/lib/karafka/core/monitoring/statistics_decorator.rb
@@ -8,9 +8,26 @@ module Karafka
       # instead of being a value of messages sent from the last statistics report.
       # This decorator calculates the diff against previously emited stats, so we get also
       # the diff together with the original values
+      #
+      # It adds two extra values to numerics:
+      #   - KEY_d - delta of the previous value and current
+      #   - KEY_fd - freeze duration - describes how long the delta remains unchanged (zero)
+      #              and can be useful for detecting values that "hang" for extended period of time
+      #              and do not have any change (delta always zero). This value is in ms for the
+      #              consistency with other time operators we use.
       class StatisticsDecorator
+        include Helpers::Time
+
+        # Empty hash for internal referencing
+        EMPTY_HASH = {}.freeze
+
+        private_constant :EMPTY_HASH
+
         def initialize
-          @previous = {}.freeze
+          @previous = EMPTY_HASH
+          # Operate on ms precision only
+          @previous_at = monotonic_now.round
+          @current_at = @previous_at
         end
 
         # @param emited_stats [Hash] original emited statistics
@@ -19,12 +36,17 @@ module Karafka
         #   any API to get raw data, users can just assume that the result of this decoration is
         #   the proper raw stats that they can use
         def call(emited_stats)
+          @current_at = monotonic_now.round
+
+          @change_d = @current_at - @previous_at
+
           diff(
             @previous,
             emited_stats
           )
 
           @previous = emited_stats
+          @previous_at = @current_at
 
           emited_stats.freeze
         end
@@ -45,7 +67,7 @@ module Karafka
               append(
                 current,
                 key,
-                diff((previous || {})[key], (current || {})[key])
+                diff((previous || EMPTY_HASH)[key], (current || EMPTY_HASH)[key])
               )
             end
           end
@@ -68,6 +90,15 @@ module Karafka
         def append(current, key, result)
           return unless result.is_a?(Numeric)
           return if current.frozen?
+
+          freeze_duration_key = "#{key}_fd"
+
+          if result.zero?
+            current[freeze_duration_key] ||= 0
+            current[freeze_duration_key] += @change_d
+          else
+            current[freeze_duration_key] = 0
+          end
 
           current["#{key}_d"] = result
         end

--- a/lib/karafka/core/version.rb
+++ b/lib/karafka/core/version.rb
@@ -4,6 +4,6 @@ module Karafka
   module Core
     # Current Karafka::Core version
     # We follow the versioning schema of given Karafka version
-    VERSION = '2.2.0'
+    VERSION = '2.2.1'
   end
 end

--- a/spec/lib/karafka/core/monitoring/statistics_decorator_spec.rb
+++ b/spec/lib/karafka/core/monitoring/statistics_decorator_spec.rb
@@ -84,10 +84,15 @@ RSpec.describe_current do
 
     it { expect(decorated['string']).to eq('value3') }
     it { expect(decorated.key?('string_d')).to eq(false) }
+    it { expect(decorated.key?('string_fd')).to eq(false) }
     it { expect(decorated['float_d'].round(10)).to eq(1.0) }
+    it { expect(decorated['float_fd']).to eq(0) }
     it { expect(decorated['int_d']).to eq(-120) }
+    it { expect(decorated['int_fd']).to eq(0) }
     it { expect(decorated.dig(*broker_scope)['txbytes_d']).to eq(-151) }
+    it { expect(decorated.dig(*broker_scope)['txbytes_fd']).to eq(0) }
     it { expect(decorated).to be_frozen }
+    it { expect(decorated.key?('float_d_d')).to eq(false) }
   end
 
   context 'when a broker is no longer present' do
@@ -100,10 +105,14 @@ RSpec.describe_current do
 
     it { expect(decorated['string']).to eq('value2') }
     it { expect(decorated.key?('string_d')).to eq(false) }
+    it { expect(decorated.key?('string_fd')).to eq(false) }
     it { expect(decorated['float_d'].round(10)).to eq(0.4) }
+    it { expect(decorated['float_fd']).to eq(0) }
     it { expect(decorated['int_d']).to eq(18) }
+    it { expect(decorated['int_fd']).to eq(0) }
     it { expect(decorated['nested']).to eq({}) }
     it { expect(decorated).to be_frozen }
+    it { expect(decorated.key?('float_d_d')).to eq(false) }
   end
 
   context 'when broker was introduced later on' do
@@ -117,8 +126,35 @@ RSpec.describe_current do
     it { expect(decorated['string']).to eq('value2') }
     it { expect(decorated.key?('string_d')).to eq(false) }
     it { expect(decorated['float_d'].round(10)).to eq(0.4) }
+    it { expect(decorated['float_fd']).to eq(0) }
     it { expect(decorated['int_d']).to eq(18) }
+    it { expect(decorated['int_fd']).to eq(0) }
     it { expect(decorated.dig(*broker_scope)['txbytes_d']).to eq(0) }
+    it { expect(decorated.dig(*broker_scope)['txbytes_fd']).to eq(0) }
     it { expect(decorated).to be_frozen }
+    it { expect(decorated.key?('float_d_d')).to eq(false) }
+  end
+
+  context 'when value remains unchanged over time' do
+    subject(:decorated) do
+      # First one will set initial state
+      decorator.call(deep_copy.call)
+      # Second one will build first deltas with freeze duration of zero
+      decorator.call(deep_copy.call)
+      sleep(0.01)
+      # Third one will allow for proper freeze duration computation
+      decorator.call(deep_copy.call)
+    end
+
+    let(:deep_copy) { -> { Marshal.load(Marshal.dump(emited_stats1)) } }
+
+    it { expect(decorated.key?('string_d')).to eq(false) }
+    it { expect(decorated.key?('string_fd')).to eq(false) }
+    it { expect(decorated['float_d']).to eq(0) }
+    it { expect(decorated['float_fd']).to be_within(5).of(10) }
+    it { expect(decorated['int_d']).to eq(0) }
+    it { expect(decorated['int_fd']).to be_within(5).of(10) }
+    it { expect(decorated).to be_frozen }
+    it { expect(decorated.key?('float_d_d')).to eq(false) }
   end
 end


### PR DESCRIPTION
This PR:
- introduces a new enrichment of data by providing `_fd` values that represent freeze duration. It is useful for things like LSO hang detection and other things that should change occasionally but are not.
- optimizes memory allocation by skipping some objects creation
- adds extra specs to ensure there's no problem with metrics value leakage.
