### PR TITLE
Provide lazy evaluated constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka core changelog
 
+### 2.2.4 (Unreleased)
+- [Enhancement] Allow for `lazy` evaluated constructors.
+
 ### 2.2.3 (2023-10-17)
 - [Change] Set minimum `karafka-rdkafka` on `0.13.6`.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka-core (2.2.3)
+    karafka-core (2.2.4)
       concurrent-ruby (>= 1.1)
       karafka-rdkafka (>= 0.13.6, < 0.14.0)
 

--- a/lib/karafka/core/configurable.rb
+++ b/lib/karafka/core/configurable.rb
@@ -65,14 +65,14 @@ module Karafka
 
         # Two versions are needed to pass arguments in the correct way
         if RUBY_VERSION >= '2.7'
-          class_eval <<~CODE, __FILE__, __LINE__
+          class_eval <<~CODE, __FILE__, __LINE__ + 1
             # Pipes the settings setup to the config root node
             def setting(...)
               config.setting(...)
             end
           CODE
         else
-          class_eval <<~CODE, __FILE__, __LINE__
+          class_eval <<~CODE, __FILE__, __LINE__ + 1
             # Pipes the settings setup to the config root node
             # @param args [Object] anything provided to settings
             # @param block [Proc] block for settings

--- a/lib/karafka/core/configurable/leaf.rb
+++ b/lib/karafka/core/configurable/leaf.rb
@@ -4,10 +4,15 @@ module Karafka
   module Core
     module Configurable
       # Single end config value representation
-      Leaf = Struct.new(:name, :default, :constructor, :compiled) do
+      Leaf = Struct.new(:name, :default, :constructor, :compiled, :lazy) do
         # @return [Boolean] true if already compiled
         def compiled?
           compiled
+        end
+
+        # @return [Boolean] is this a lazy evaluated leaf
+        def lazy?
+          lazy == true
         end
       end
     end

--- a/lib/karafka/core/configurable/node.rb
+++ b/lib/karafka/core/configurable/node.rb
@@ -117,6 +117,9 @@ module Karafka
 
             if lazy_leaf && !initialized
               build_dynamic_accessor(value)
+            elsif lazy_leaf && initialized
+              singleton_class.attr_accessor(value.name)
+              public_send("#{value.name}=", initialized)
             else
               public_send("#{value.name}=", initialized)
             end

--- a/lib/karafka/core/version.rb
+++ b/lib/karafka/core/version.rb
@@ -4,6 +4,6 @@ module Karafka
   module Core
     # Current Karafka::Core version
     # We follow the versioning schema of given Karafka version
-    VERSION = '2.2.3'
+    VERSION = '2.2.4'
   end
 end


### PR DESCRIPTION
close https://github.com/karafka/karafka-core/issues/70

allows for lazy evaluated settings. Useful for web-ui alternative producer overwrite option and default that goes to `Karafka.producer` that may not yet be available during the setup evaluation.