### PR TITLE
ruby 3.3.0-rc1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '3.3.0-preview2'
+          - '3.3.0-rc1'
           - '3.2'
           - '3.1'
           - '3.0'


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2023/12/11/ruby-3-3-0-rc1-released/