### PR TITLE
Allow clearing one event type

### DIFF
--- a/lib/karafka/core/monitoring/notifications.rb
+++ b/lib/karafka/core/monitoring/notifications.rb
@@ -39,9 +39,13 @@ module Karafka
         end
 
         # Clears all the subscribed listeners
-        def clear
+        def clear(event=nil)
           @mutex.synchronize do
-            @listeners.each_value(&:clear)
+            if event
+              @listeners[event].clear
+            else
+              @listeners.each_value(&:clear)
+            end
           end
         end
 

--- a/spec/lib/karafka/core/monitoring/notifications_spec.rb
+++ b/spec/lib/karafka/core/monitoring/notifications_spec.rb
@@ -62,12 +62,32 @@ RSpec.describe_current do
   end
 
   describe '#clear' do
-    before { notifications.subscribe(event_name) { raise } }
 
-    it 'expect not to raise any errors as after clearing subscription should no longer work' do
-      notifications.clear
-      notifications.instrument(event_name)
+    describe 'without an argument' do
+      before { notifications.subscribe(event_name) { raise } }
+
+      it 'expect not to raise any errors as after clearing subscription should no longer work' do
+        notifications.clear
+        notifications.instrument(event_name)
+      end
     end
+
+    describe 'one event given' do
+      let(:instrumented) { [] }
+      before do
+        notifications.register_event("some-other-event")
+        notifications.subscribe(event_name) { instrumented.push(1) } # it's fine
+        notifications.subscribe("some-other-event") { instrumented.push(2) }
+      end
+
+      it 'expect to only get one event' do
+        notifications.clear('some-other-event')
+        notifications.instrument(event_name)
+        notifications.instrument("some-other-event")
+        expect(instrumented).to eq([1])
+      end
+    end
+
   end
 
   describe 'subscription and instrumentation flow' do


### PR DESCRIPTION
This is a tiny PR to allow clearing just a single event. This is useful for testing purposes if we want to add some notifications just for the purpose of a test, and then put the state back the way it was.