### PR TITLE
save on memory allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka core changelog
 
 ## 2.4.1 (Unreleased)
+- [Enhancement] Save memory allocation on each contract rule validation execution.
 - [Enhancement] Save one allocation per `float_now` + 2-3x performance by using the Posix clock instead of `Time.now.utc.to_f`.
 - [Enhancement] Use direct `float_millisecond` precision in `monotonic_now` not to multiply by 1000 (allocations and CPU savings).
 - [Enhancement] Save one array allocation on one instrumentation.

--- a/lib/karafka/core/helpers/time.rb
+++ b/lib/karafka/core/helpers/time.rb
@@ -20,7 +20,7 @@ module Karafka
 
         # @return [Float] current time in float
         def float_now
-          ::Process.clock_gettime(Process::CLOCK_REALTIME)
+          ::Process.clock_gettime(::Process::CLOCK_REALTIME)
         end
       end
     end


### PR DESCRIPTION
This PR saves memory allocation by using one return value instead of array, so the lookup does not create a new array per validation.
It also replaces `map` pointless usage with `each`

This PR also fixes root reference to process clock