### PR TITLE
Provide fast-track for non-subscribed code and save object allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka core changelog
 
 ## 2.4.1 (Unreleased)
+- [Enhancement] Provide fast-track for events without subscriptions to save on allocations.
 - [Enhancement] Save memory allocation on each contract rule validation execution.
 - [Enhancement] Save one allocation per `float_now` + 2-3x performance by using the Posix clock instead of `Time.now.utc.to_f`.
 - [Enhancement] Use direct `float_millisecond` precision in `monotonic_now` not to multiply by 1000 (allocations and CPU savings).

--- a/lib/karafka/core/monitoring/notifications.rb
+++ b/lib/karafka/core/monitoring/notifications.rb
@@ -115,9 +115,9 @@ module Karafka
             start = monotonic_now
             result = yield
             time = monotonic_now - start
-          else
+          elsif assigned_listeners.empty?
             # Skip measuring or doing anything if no one listening
-            return if assigned_listeners.empty?
+            return
           end
 
           event = Event.new(


### PR DESCRIPTION
short track improvement before:

```
 1.830753   0.005683   1.836436 (  1.843820)
```

after:

```
0.759046   0.000000   0.759046 (  0.759051)
```


instrumented code (no difference in performance, but less objects allocated):

```
1.916583   0.068589   1.985172 (  2.019679)
```

vs

```
1.917342   0.000666   1.918008 (  1.921659)
```