### PR TITLE
declare logger as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka Core Changelog
 
+## 2.4.8 (Unreleased)
+- [Maintenance] Declare `logger` as a dependency.
+
 ## 2.4.7 (2024-11-26)
 - [Fix] Make sure that `karafka-core` works with older versions of `karafka-rdkafka` that do not support macos fork mitigation.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    karafka-core (2.4.7)
+    karafka-core (2.4.8)
       karafka-rdkafka (>= 0.17.6, < 0.19.0)
+      logger (>= 1.6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/karafka-core.gemspec
+++ b/karafka-core.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.licenses    = %w[MIT]
 
   spec.add_dependency 'karafka-rdkafka', '>= 0.17.6', '< 0.19.0'
+  spec.add_dependency 'logger', '>= 1.6.0'
 
   spec.required_ruby_version = '>= 3.1.0'
 

--- a/lib/karafka-core.rb
+++ b/lib/karafka-core.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 %w[
+  logger
   yaml
   rdkafka
 

--- a/lib/karafka/core/version.rb
+++ b/lib/karafka/core/version.rb
@@ -4,6 +4,6 @@ module Karafka
   module Core
     # Current Karafka::Core version
     # We follow the versioning schema of given Karafka version
-    VERSION = '2.4.7'
+    VERSION = '2.4.8'
   end
 end


### PR DESCRIPTION
Since both waterdrop and karafka use logger, this should go here because logger was moved to a gem: https://rubygems.org/gems/logger