### PR TITLE
Allow for name as config name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka Core Changelog
 
+## 2.4.11 (Unreleased)
+- [Enhancement] Rename internal node `#name` method to `#node_name` so we can use `#name` as the attribute name.
+
 ## 2.4.10 (2025-03-14)
 - [Fix] Relax lock on `karafka-rdkafka`
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka-core (2.4.10)
+    karafka-core (2.4.11)
       karafka-rdkafka (>= 0.17.6, < 0.20.0)
       logger (>= 1.6.0)
 

--- a/lib/karafka/core/configurable/leaf.rb
+++ b/lib/karafka/core/configurable/leaf.rb
@@ -4,7 +4,7 @@ module Karafka
   module Core
     module Configurable
       # Single end config value representation
-      Leaf = Struct.new(:name, :default, :constructor, :compiled, :lazy) do
+      Leaf = Struct.new(:node_name, :default, :constructor, :compiled, :lazy) do
         # @return [Boolean] true if already compiled
         def compiled?
           compiled

--- a/lib/karafka/core/configurable/node.rb
+++ b/lib/karafka/core/configurable/node.rb
@@ -58,13 +58,13 @@ module Karafka
 
           @children.each do |value|
             config[value.node_name] = if value.is_a?(Leaf)
-                                   result = public_send(value.node_name)
-                                   # We need to check if value is not a result node for cases where
-                                   # we merge additional config
-                                   result.is_a?(Node) ? result.to_h : result
-                                 else
-                                   value.to_h
-                                 end
+                                        result = public_send(value.node_name)
+                                        # We need to check if value is not a result node for cases
+                                        # where we merge additional config
+                                        result.is_a?(Node) ? result.to_h : result
+                                      else
+                                        value.to_h
+                                      end
           end
 
           config.freeze

--- a/lib/karafka/core/configurable/node.rb
+++ b/lib/karafka/core/configurable/node.rb
@@ -10,15 +10,15 @@ module Karafka
       # we only compile/initialize the values prior to user running the `#configure` API. This API
       # needs to run prior to using the result stuff even if there is nothing to configure
       class Node
-        attr_reader :name, :nestings
+        attr_reader :node_name, :nestings
 
         # We need to be able to redefine children for deep copy
         attr_accessor :children
 
-        # @param name [Symbol] node name
+        # @param node_name [Symbol] node name
         # @param nestings [Proc] block for nested settings
-        def initialize(name, nestings = ->(_) {})
-          @name = name
+        def initialize(node_name, nestings = ->(_) {})
+          @node_name = node_name
           @children = []
           @nestings = nestings
           @compiled = false
@@ -27,16 +27,16 @@ module Karafka
 
         # Allows for a single leaf or nested node definition
         #
-        # @param name [Symbol] setting or nested node name
+        # @param node_name [Symbol] setting or nested node name
         # @param default [Object] default value
         # @param constructor [#call, nil] callable or nil
         # @param lazy [Boolean] is this a lazy leaf
         # @param block [Proc] block for nested settings
-        def setting(name, default: nil, constructor: nil, lazy: false, &block)
+        def setting(node_name, default: nil, constructor: nil, lazy: false, &block)
           @children << if block
-                         Node.new(name, block)
+                         Node.new(node_name, block)
                        else
-                         Leaf.new(name, default, constructor, false, lazy)
+                         Leaf.new(node_name, default, constructor, false, lazy)
                        end
 
           compile
@@ -47,7 +47,7 @@ module Karafka
         # Compile settings, allow for overrides via yielding
         # @return [Node] returns self after configuration
         def configure
-          compile if !@compiled || name == :root
+          compile if !@compiled || node_name == :root
           yield(self) if block_given?
           self
         end
@@ -57,8 +57,8 @@ module Karafka
           config = {}
 
           @children.each do |value|
-            config[value.name] = if value.is_a?(Leaf)
-                                   result = public_send(value.name)
+            config[value.node_name] = if value.is_a?(Leaf)
+                                   result = public_send(value.node_name)
                                    # We need to check if value is not a result node for cases where
                                    # we merge additional config
                                    result.is_a?(Node) ? result.to_h : result
@@ -74,7 +74,7 @@ module Karafka
         # and non-side-effect usage on an instance/inherited.
         # @return [Node] duplicated node
         def deep_dup
-          dupped = Node.new(name, nestings)
+          dupped = Node.new(node_name, nestings)
 
           dupped.children += children.map do |value|
             if value.is_a?(Leaf)
@@ -96,12 +96,12 @@ module Karafka
           @children.each do |value|
             # Do not redefine something that was already set during compilation
             # This will allow us to reconfigure things and skip override with defaults
-            skippable = respond_to?(value.name) || (value.is_a?(Leaf) && value.compiled?)
+            skippable = respond_to?(value.node_name) || (value.is_a?(Leaf) && value.compiled?)
             lazy_leaf = value.is_a?(Leaf) && value.lazy?
 
             # Do not create accessor for leafs that are lazy as they will get a custom method
             # created instead
-            singleton_class.attr_accessor(value.name) unless lazy_leaf
+            singleton_class.attr_accessor(value.node_name) unless lazy_leaf
 
             next if skippable
 
@@ -123,7 +123,7 @@ module Karafka
             if lazy_leaf && !initialized
               build_dynamic_accessor(value)
             else
-              public_send("#{value.name}=", initialized)
+              public_send("#{value.node_name}=", initialized)
             end
           end
 
@@ -139,16 +139,16 @@ module Karafka
         #
         # @param value [Leaf]
         def build_dynamic_accessor(value)
-          singleton_class.attr_writer(value.name)
+          singleton_class.attr_writer(value.node_name)
 
-          define_singleton_method(value.name) do
-            existing = instance_variable_get("@#{value.name}")
+          define_singleton_method(value.node_name) do
+            existing = instance_variable_get("@#{value.node_name}")
 
             return existing if existing
 
             built = call_constructor(value)
 
-            instance_variable_set("@#{value.name}", built)
+            instance_variable_set("@#{value.node_name}", built)
           end
         end
 

--- a/lib/karafka/core/version.rb
+++ b/lib/karafka/core/version.rb
@@ -4,6 +4,6 @@ module Karafka
   module Core
     # Current Karafka::Core version
     # We follow the versioning schema of given Karafka version
-    VERSION = '2.4.10'
+    VERSION = '2.4.11'
   end
 end

--- a/spec/lib/karafka/core/configurable_spec.rb
+++ b/spec/lib/karafka/core/configurable_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe_current do
             setting(:with_constructor, default: false, constructor: ->(default) { default || 5 })
             setting(:ov_constructor, default: true, constructor: ->(default) { default || 5 })
             setting(:with_zero_constructor, constructor: -> { 7 })
+            setting(:name, default: 'name')
           end
 
           setting(:nested1, default: 1)
@@ -33,6 +34,7 @@ RSpec.describe_current do
       before { configurable_class.configure }
 
       it { expect(config.with_default).to eq(123) }
+      it { expect(config.nested1.nested2.name).to eq('name') }
       it { expect(config.nested1.nested2.leaf).to eq(6) }
       it { expect(config.nested1.nested1).to eq(1) }
       it { expect(config.nested1.nested2.with_constructor).to eq(5) }
@@ -122,6 +124,7 @@ RSpec.describe_current do
           nested1: {
             nested1: 1,
             nested2: {
+              name: 'name',
               leaf: 6,
               ov_constructor: true,
               with_constructor: 5,


### PR DESCRIPTION
This PR solves the issue that we were not able to use `name` as a setting name. This was problematic because we want to use the `name` as an attribute like `topics.consumers_reports.name` but until now it was not possible