### PR TITLE
normalize require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Karafka Core Changelog
 
 ## 2.5.6 (Unreleased)
-- [Change] Normalize how libs and deps are required (no functional change for the end user)
+- [Change] Normalize how libs and dependencies are required (no functional change for the end user)
 
 ## 2.5.5 (2025-08-04)
 - [Enhancement] Remove reliance on `Set` class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka Core Changelog
 
+## 2.5.6 (Unreleased)
+- [Change] Normalize how libs and deps are required (no functional change for the end user)
+
 ## 2.5.5 (2025-08-04)
 - [Enhancement] Remove reliance on `Set` class.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka-core (2.5.5)
+    karafka-core (2.5.6)
       karafka-rdkafka (>= 0.19.2, < 0.21.0)
       logger (>= 1.6.0)
 

--- a/lib/karafka-core.rb
+++ b/lib/karafka-core.rb
@@ -1,37 +1,27 @@
 # frozen_string_literal: true
 
-%w[
-  logger
-  yaml
-  rdkafka
-
-  karafka/core
-  karafka/core/version
-
-  karafka/core/helpers/time
-
-  karafka/core/monitoring
-  karafka/core/monitoring/event
-  karafka/core/monitoring/monitor
-  karafka/core/monitoring/notifications
-  karafka/core/monitoring/statistics_decorator
-
-  karafka/core/configurable
-  karafka/core/configurable/leaf
-  karafka/core/configurable/node
-
-  karafka/core/contractable/contract
-  karafka/core/contractable/result
-  karafka/core/contractable/rule
-
-  karafka/core/instrumentation
-  karafka/core/instrumentation/callbacks_manager
-
-  karafka/core/taggable
-  karafka/core/taggable/tags
-
-  karafka/core/patches/rdkafka/bindings
-].each { |dependency| require dependency }
+require 'logger'
+require 'yaml'
+require 'rdkafka'
+require 'karafka/core'
+require 'karafka/core/version'
+require 'karafka/core/helpers/time'
+require 'karafka/core/monitoring'
+require 'karafka/core/monitoring/event'
+require 'karafka/core/monitoring/monitor'
+require 'karafka/core/monitoring/notifications'
+require 'karafka/core/monitoring/statistics_decorator'
+require 'karafka/core/configurable'
+require 'karafka/core/configurable/leaf'
+require 'karafka/core/configurable/node'
+require 'karafka/core/contractable/contract'
+require 'karafka/core/contractable/result'
+require 'karafka/core/contractable/rule'
+require 'karafka/core/instrumentation'
+require 'karafka/core/instrumentation/callbacks_manager'
+require 'karafka/core/taggable'
+require 'karafka/core/taggable/tags'
+require 'karafka/core/patches/rdkafka/bindings'
 
 # Karafka framework main namespace
 module Karafka

--- a/lib/karafka/core/version.rb
+++ b/lib/karafka/core/version.rb
@@ -4,6 +4,6 @@ module Karafka
   module Core
     # Current Karafka::Core version
     # We follow the versioning schema of given Karafka version
-    VERSION = '2.5.5'
+    VERSION = '2.5.6'
   end
 end


### PR DESCRIPTION
I am reverting this require style because in case of any bundler and zeitwerk require related issues, the line points to require and its hard to resolve what lib operations failed.