### PR TITLE
Apply 7-day minimum release age to all packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,9 @@
       "matchManagers": [
         "github-actions"
       ],
+      "pinDigests": true
+    },
+    {
       "minimumReleaseAge": "7 days"
     }
   ]


### PR DESCRIPTION
## Summary
- Move `minimumReleaseAge` rule to a separate packageRule without `matchManagers` filter
- This ensures the 7-day cooldown period applies to all package managers, not just github-actions

## Test plan
- Verify Renovate validates the configuration successfully
- Future PRs from Renovate should respect the 7-day cooldown for all dependencies