### PR TITLE
Update .yard-lint.yml with new validators from yard-lint 1.3.0

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -3,172 +3,274 @@
 
 # Global settings for all validators
 AllValidators:
-  # YARD command-line options (applied to all validators by default)
   YardOptions:
-    - --private
-    - --protected
-
-  # Global file exclusion patterns
+  - "--private"
+  - "--protected"
   Exclude:
-    - '\.git'
-    - 'vendor/**/*'
-    - 'node_modules/**/*'
-    - 'spec/**/*'
-    - 'test/**/*'
-
-  # Exit code behavior (error, warning, convention, never)
+  - "\\.git"
+  - vendor/**/*
+  - node_modules/**/*
+  - spec/**/*
+  - test/**/*
   FailOnSeverity: convention
-
-  # Minimum documentation coverage percentage (0-100)
-  # Fails if coverage is below this threshold
   MinCoverage: 98.0
-
-  # Diff mode settings
   DiffMode:
-    # Default base ref for --diff (auto-detects main/master if not specified)
-    DefaultBaseRef: ~
+    DefaultBaseRef:
 
 # Documentation validators
 Documentation/UndocumentedObjects:
-  Description: 'Checks for classes, modules, and methods without documentation.'
+  Description: Checks for classes, modules, and methods without documentation.
   Enabled: true
   Severity: error
   ExcludedMethods:
-    - 'initialize/0'  # Exclude parameter-less initialize
-    - '/^_/'          # Exclude private methods (by convention)
+  - initialize/0
+  - "/^_/"
 
 Documentation/UndocumentedMethodArguments:
-  Description: 'Checks for method parameters without @param tags.'
+  Description: Checks for method parameters without @param tags.
   Enabled: true
   Severity: error
 
 Documentation/UndocumentedBooleanMethods:
-  Description: 'Checks that question mark methods document their boolean return.'
+  Description: Checks that question mark methods document their boolean return.
   Enabled: true
   Severity: error
 
 Documentation/UndocumentedOptions:
-  Description: 'Detects methods with options hash parameters but no @option tags.'
+  Description: Detects methods with options hash parameters but no @option tags.
   Enabled: true
   Severity: error
 
 Documentation/MarkdownSyntax:
-  Description: 'Detects common markdown syntax errors in documentation.'
+  Description: Detects common markdown syntax errors in documentation.
   Enabled: true
   Severity: error
+
+Documentation/EmptyCommentLine:
+  Description: Detects empty comment lines at the start or end of documentation blocks.
+  Enabled: true
+  Severity: convention
+  EnabledPatterns:
+    Leading: true
+    Trailing: true
+
+Documentation/BlankLineBeforeDefinition:
+  Description: Detects blank lines between YARD documentation and method definition.
+  Enabled: true
+  Severity: convention
+  OrphanedSeverity: convention
+  EnabledPatterns:
+    SingleBlankLine: true
+    OrphanedDocs: true
 
 # Tags validators
 Tags/Order:
-  Description: 'Enforces consistent ordering of YARD tags.'
+  Description: Enforces consistent ordering of YARD tags.
   Enabled: true
   Severity: error
   EnforcedOrder:
-    - param
-    - option
-    - return
-    - raise
-    - example
+  - param
+  - option
+  - return
+  - raise
+  - example
 
 Tags/InvalidTypes:
-  Description: 'Validates type definitions in @param, @return, @option tags.'
+  Description: Validates type definitions in @param, @return, @option tags.
   Enabled: true
   Severity: error
   ValidatedTags:
-    - param
-    - option
-    - return
+  - param
+  - option
+  - return
 
 Tags/TypeSyntax:
-  Description: 'Validates YARD type syntax using YARD parser.'
+  Description: Validates YARD type syntax using YARD parser.
   Enabled: true
   Severity: error
   ValidatedTags:
-    - param
-    - option
-    - return
-    - yieldreturn
+  - param
+  - option
+  - return
+  - yieldreturn
 
 Tags/MeaninglessTag:
-  Description: 'Detects @param/@option tags on classes, modules, or constants.'
+  Description: Detects @param/@option tags on classes, modules, or constants.
   Enabled: true
   Severity: error
   CheckedTags:
-    - param
-    - option
+  - param
+  - option
   InvalidObjectTypes:
-    - class
-    - module
-    - constant
+  - class
+  - module
+  - constant
 
 Tags/CollectionType:
-  Description: 'Validates Hash collection syntax consistency.'
+  Description: Validates Hash collection syntax consistency.
   Enabled: true
   Severity: error
-  EnforcedStyle: long  # 'long' for Hash{K => V} (YARD standard), 'short' for {K => V}
+  EnforcedStyle: long
   ValidatedTags:
-    - param
-    - option
-    - return
-    - yieldreturn
+  - param
+  - option
+  - return
+  - yieldreturn
 
 Tags/TagTypePosition:
-  Description: 'Validates type annotation position in tags.'
+  Description: Validates type annotation position in tags.
   Enabled: true
   Severity: error
   CheckedTags:
-    - param
-    - option
-  # EnforcedStyle: 'type_after_name' (YARD standard: @param name [Type])
-  #                or 'type_first' (@param [Type] name)
+  - param
+  - option
   EnforcedStyle: type_after_name
 
 Tags/ApiTags:
-  Description: 'Enforces @api tags on public objects.'
-  Enabled: false  # Opt-in validator
+  Description: Enforces @api tags on public objects.
+  Enabled: false
   Severity: error
   AllowedApis:
-    - public
-    - private
-    - internal
+  - public
+  - private
+  - internal
 
 Tags/OptionTags:
-  Description: 'Requires @option tags for methods with options parameters.'
+  Description: Requires @option tags for methods with options parameters.
   Enabled: true
   Severity: error
 
+Tags/ExampleSyntax:
+  Description: Validates Ruby syntax in @example tags.
+  Enabled: true
+  Severity: warning
+
+Tags/RedundantParamDescription:
+  Description: Detects meaningless parameter descriptions that add no value.
+  Enabled: true
+  Severity: convention
+  CheckedTags:
+  - param
+  - option
+  Articles:
+  - The
+  - the
+  - A
+  - a
+  - An
+  - an
+  MaxRedundantWords: 6
+  GenericTerms:
+  - object
+  - instance
+  - value
+  - data
+  - item
+  - element
+  EnabledPatterns:
+    ArticleParam: true
+    PossessiveParam: true
+    TypeRestatement: true
+    ParamToVerb: true
+    IdPattern: true
+    DirectionalDate: true
+    TypeGeneric: true
+
+Tags/InformalNotation:
+  Description: Detects informal tag notation patterns like "Note:" instead of @note.
+  Enabled: true
+  Severity: warning
+  CaseSensitive: false
+  RequireStartOfLine: true
+  Patterns:
+    Note: "@note"
+    Todo: "@todo"
+    TODO: "@todo"
+    FIXME: "@todo"
+    See: "@see"
+    See also: "@see"
+    Warning: "@deprecated"
+    Deprecated: "@deprecated"
+    Author: "@author"
+    Version: "@version"
+    Since: "@since"
+    Returns: "@return"
+    Raises: "@raise"
+    Example: "@example"
+
+Tags/NonAsciiType:
+  Description: Detects non-ASCII characters in type annotations.
+  Enabled: true
+  Severity: warning
+  ValidatedTags:
+  - param
+  - option
+  - return
+  - yieldreturn
+  - yieldparam
+
+Tags/TagGroupSeparator:
+  Description: Enforces blank line separators between different YARD tag groups.
+  Enabled: false
+  Severity: convention
+  TagGroups:
+    param:
+    - param
+    - option
+    return:
+    - return
+    error:
+    - raise
+    - throws
+    example:
+    - example
+    meta:
+    - see
+    - note
+    - todo
+    - deprecated
+    - since
+    - version
+    - api
+    yield:
+    - yield
+    - yieldparam
+    - yieldreturn
+  RequireAfterDescription: false
+
 # Warnings validators - catches YARD parser errors
 Warnings/UnknownTag:
-  Description: 'Detects unknown YARD tags.'
+  Description: Detects unknown YARD tags.
   Enabled: true
   Severity: error
 
 Warnings/UnknownDirective:
-  Description: 'Detects unknown YARD directives.'
+  Description: Detects unknown YARD directives.
   Enabled: true
   Severity: error
 
 Warnings/InvalidTagFormat:
-  Description: 'Detects malformed tag syntax.'
+  Description: Detects malformed tag syntax.
   Enabled: true
   Severity: error
 
 Warnings/InvalidDirectiveFormat:
-  Description: 'Detects malformed directive syntax.'
+  Description: Detects malformed directive syntax.
   Enabled: true
   Severity: error
 
 Warnings/DuplicatedParameterName:
-  Description: 'Detects duplicate @param tags.'
+  Description: Detects duplicate @param tags.
   Enabled: true
   Severity: error
 
 Warnings/UnknownParameterName:
-  Description: 'Detects @param tags for non-existent parameters.'
+  Description: Detects @param tags for non-existent parameters.
   Enabled: true
   Severity: error
 
 # Semantic validators
 Semantic/AbstractMethods:
-  Description: 'Ensures @abstract methods do not have real implementations.'
+  Description: Ensures @abstract methods do not have real implementations.
   Enabled: true
   Severity: error


### PR DESCRIPTION
## Summary
- Update `.yard-lint.yml` configuration file using the new `yard-lint --update` command
- Add 7 new validators introduced in yard-lint 1.3.0:
  - `Documentation/BlankLineBeforeDefinition` - detects blank lines between YARD docs and method definition
  - `Documentation/EmptyCommentLine` - detects empty comment lines at start/end of doc blocks
  - `Tags/ExampleSyntax` - validates Ruby syntax in @example tags
  - `Tags/InformalNotation` - detects informal tag notation (e.g., "Note:" instead of @note)
  - `Tags/NonAsciiType` - detects non-ASCII characters in type annotations
  - `Tags/RedundantParamDescription` - detects meaningless parameter descriptions
  - `Tags/TagGroupSeparator` - enforces blank line separators between tag groups (disabled by default)

## Test plan
- [x] Run `bundle exec yard-lint` - no offenses found
- [x] All new validators enabled by default are active
- [x] Validators disabled by default remain disabled (`Tags/TagGroupSeparator`)