### PR TITLE
Enable opt-in Ruby warning categories in test helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka Core Changelog
 
+## 2.5.14 (2026-06-02)
+- [Enhancement] Replace version-gated `Warning[:performance]` with a `Warning.categories`-based loop that enables all opt-in Ruby warning categories automatically, picking up new categories (e.g. `strict_unused_block` in Ruby 3.4+) without future patches.
+
 ## 2.5.13 (2026-04-08)
 - [Enhancement] Extract `decorate_partitions` method from `StatisticsDecorator` to allow subclasses to filter which partitions are decorated (e.g. skip unassigned partitions in a consumer context).
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
-Warning[:performance] = true if RUBY_VERSION >= "3.3"
 Warning[:deprecated] = true
 $VERBOSE = true
 
 require "warning"
+
+# Enable all opt-in warning categories. Warning.categories is available
+# since Ruby 3.4; on older Rubies this is a no-op.
+if Warning.respond_to?(:categories)
+  (Warning.categories - %i[deprecated experimental]).each { |cat| Warning[cat] = true }
+end
 
 Warning.process do |warning|
   next unless warning.include?(Dir.pwd)


### PR DESCRIPTION
Replace the version-gated Warning[:performance] line with a Warning.categories loop that enables all opt-in categories automatically. New categories like strict_unused_block (Ruby 3.4+) are picked up without needing future patches.