### PR TITLE
Align wrapped comment lines to the line length limit

### DIFF
--- a/lib/karafka/core/configurable/node.rb
+++ b/lib/karafka/core/configurable/node.rb
@@ -89,8 +89,7 @@ module Karafka
 
           children.each do |value|
             dupped.children << if value.is_a?(Leaf)
-              # After inheritance we need to reload the state so the leafs are
-              # recompiled again
+              # After inheritance we need to reload the state so the leafs are recompiled again
               value = value.dup
               value.compiled = false
               value
@@ -146,8 +145,7 @@ module Karafka
 
         # Defines a lazy evaluated read and writer that will re-evaluate in case value constructor
         # evaluates to `nil` or `false`. This allows us to define dynamic constructors that
-        # can react to external conditions to become expected value once this value is
-        # available
+        # can react to external conditions to become expected value once this value is available
         #
         # @param value [Leaf]
         def build_dynamic_accessor(value)

--- a/lib/karafka/core/contractable/contract.rb
+++ b/lib/karafka/core/contractable/contract.rb
@@ -131,8 +131,7 @@ module Karafka
         def validate_required(data, rule, errors, scope)
           for_checking = dig(data, rule.path)
 
-          # We need to compare `DIG_MISS` against stuff because of the ownership of the `#==`
-          # method
+          # We need to compare `DIG_MISS` against stuff because of the ownership of the `#==` method
           if for_checking == DIG_MISS
             errors << [scope + rule.path, :missing]
           else


### PR DESCRIPTION
Join prose comment lines that were split mid-sentence with no reason to stay under the line length limit. Skips license headers, YARD tags, code examples, feature-list bullets, and conceptually separate sentences.