### PR TITLE
Add Node#register for runtime key-value registration on compiled nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka Core Changelog
 
+## 2.5.15 (Unreleased)
+- [Enhancement] Add `Node#register` to allow runtime key-value registration on compiled nodes without going through the static `setting` DSL. Useful for dynamic registries (e.g. named clusters) where setting names are not known at class-load time.
+
 ## 2.5.14 (2026-06-02)
 - [Enhancement] Replace version-gated `Warning[:performance]` with a `Warning.categories`-based loop that enables all opt-in Ruby warning categories automatically, picking up new categories (e.g. `strict_unused_block` in Ruby 3.4+) without future patches.
 

--- a/lib/karafka/core/configurable/node.rb
+++ b/lib/karafka/core/configurable/node.rb
@@ -101,6 +101,32 @@ module Karafka
           dupped
         end
 
+        # Registers a key-value pair as a setting on an already-compiled node without going
+        # through the static `setting` DSL. Useful for dynamic registries (e.g. named clusters)
+        # where the keys are not known at class-load time.
+        #
+        # Unlike `setting`, which is designed to be called at class-definition time, `register`
+        # is safe to call at runtime because it:
+        #   - appends a pre-compiled Leaf so `deep_dup` and `to_h` include it
+        #   - sets `@configs_refs` directly so the reader accessor returns the value immediately
+        #   - builds reader/writer accessors via the same `build_accessors` path
+        #
+        # Raises `ArgumentError` if the name is already registered to prevent silent overwrites.
+        #
+        # @param name [Symbol, String] setting name
+        # @param value [Object] value to store
+        # @raise [ArgumentError] when the name is already taken
+        def register(name, value)
+          name = name.to_sym
+
+          raise ArgumentError, "#{name} is already registered" if @configs_refs.key?(name)
+
+          leaf = Leaf.new(name, value, nil, true, false)
+          @children << leaf
+          build_accessors(leaf)
+          @configs_refs[name] = value
+        end
+
         # Converts the settings definitions into end children
         # @note It runs once, after things are compiled, they will not be recompiled again
         def compile

--- a/lib/karafka/core/configurable/node.rb
+++ b/lib/karafka/core/configurable/node.rb
@@ -114,7 +114,8 @@ module Karafka
         # Raises `ArgumentError` if the name is already registered to prevent silent overwrites.
         #
         # @param name [Symbol, String] setting name
-        # @param value [Object] value to store
+        # @param value [Object] the setting value assigned immediately; also used as the default
+        #   when the node is deep-duped and recompiled on a new instance
         # @raise [ArgumentError] when the name is already taken
         def register(name, value)
           name = name.to_sym

--- a/test/lib/karafka/core/configurable_test.rb
+++ b/test/lib/karafka/core/configurable_test.rb
@@ -30,6 +30,96 @@ describe_current do
       it { assert_equal 7, configurable_class.config.testme }
     end
 
+    describe "#register" do
+      let(:node) { configurable_class.config }
+
+      context "when registering a new key-value pair" do
+        before { node.register(:my_cluster, { "bootstrap.servers": "kafka:9092" }) }
+
+        it "makes the value readable via accessor" do
+          assert_equal({ "bootstrap.servers": "kafka:9092" }, node.my_cluster)
+        end
+
+        it "makes the value writable via accessor" do
+          node.my_cluster = { "bootstrap.servers": "other:9092" }
+          assert_equal({ "bootstrap.servers": "other:9092" }, node.my_cluster)
+        end
+
+        it "includes the registered key in to_h" do
+          assert node.to_h.key?(:my_cluster)
+          assert_equal({ "bootstrap.servers": "kafka:9092" }, node.to_h[:my_cluster])
+        end
+
+        it "carries the registered key through deep_dup" do
+          dupped = node.deep_dup
+          dupped.configure
+          assert_equal({ "bootstrap.servers": "kafka:9092" }, dupped.my_cluster)
+        end
+      end
+
+      context "when registering a string name" do
+        before { node.register("analytics", 42) }
+
+        it "coerces the name to a symbol" do
+          assert_equal 42, node.analytics
+        end
+      end
+
+      context "when registering multiple keys" do
+        before do
+          node.register(:cluster_a, "a:9092")
+          node.register(:cluster_b, "b:9092")
+        end
+
+        it "stores all keys independently" do
+          assert_equal "a:9092", node.cluster_a
+          assert_equal "b:9092", node.cluster_b
+        end
+
+        it "includes all keys in to_h" do
+          assert_equal "a:9092", node.to_h[:cluster_a]
+          assert_equal "b:9092", node.to_h[:cluster_b]
+        end
+      end
+
+      context "when registering a duplicate name" do
+        before { node.register(:taken, "first") }
+
+        it "raises ArgumentError" do
+          assert_raises(ArgumentError) { node.register(:taken, "second") }
+        end
+
+        it "does not overwrite the original value" do
+          node.register(:taken, "second") rescue nil
+          assert_equal "first", node.taken
+        end
+      end
+
+      context "when the registered value is nil" do
+        before { node.register(:nullable, nil) }
+
+        it "stores and returns nil" do
+          assert_nil node.nullable
+        end
+
+        it "includes the key in to_h" do
+          assert node.to_h.key?(:nullable)
+        end
+      end
+
+      context "when registering on a nested node" do
+        before { configurable_class.config.nested1.register(:extra, "nested-value") }
+
+        it "makes the value readable on the nested node" do
+          assert_equal "nested-value", configurable_class.config.nested1.extra
+        end
+
+        it "includes it in the nested node's to_h" do
+          assert_equal "nested-value", configurable_class.config.nested1.to_h[:extra]
+        end
+      end
+    end
+
     context "when we do not override any settings" do
       before { configurable_class.configure }
 

--- a/test/lib/karafka/core/configurable_test.rb
+++ b/test/lib/karafka/core/configurable_test.rb
@@ -42,6 +42,7 @@ describe_current do
 
         it "makes the value writable via accessor" do
           node.my_cluster = { "bootstrap.servers": "other:9092" }
+
           assert_equal({ "bootstrap.servers": "other:9092" }, node.my_cluster)
         end
 
@@ -53,6 +54,7 @@ describe_current do
         it "carries the registered key through deep_dup" do
           dupped = node.deep_dup
           dupped.configure
+
           assert_equal({ "bootstrap.servers": "kafka:9092" }, dupped.my_cluster)
         end
       end
@@ -90,7 +92,12 @@ describe_current do
         end
 
         it "does not overwrite the original value" do
-          node.register(:taken, "second") rescue nil
+          begin
+            node.register(:taken, "second")
+          rescue ArgumentError
+            nil
+          end
+
           assert_equal "first", node.taken
         end
       end


### PR DESCRIPTION
Adds a `register(name, value)` method to `Karafka::Core::Configurable::Node` that allows dynamic settings to be added after the node is compiled, without going through the static `setting` DSL. Appends a pre-compiled Leaf so the entry is visible to `to_h`, `deep_dup`, and `compile`. Raises `ArgumentError` on duplicate names to prevent silent overwrites.