### PR TITLE
Use ivar-backed attr_reader accessors for Configurable::Node settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Karafka Core Changelog
 
+## 2.6.1 (2026-06-11)
+- [Enhancement] Mirror config values into instance variables and use `attr_reader` based readers in `Configurable::Node`, yielding ~1.4x faster flat and ~1.6x faster nested settings reads on hot paths. `@configs_refs` remains the canonical store; non-identifier setting names (e.g. registered names with dashes) keep the previous hash-based accessors.
+- [Enhancement] Instantiate each `Configurable::Node` through a per-layout anonymous subclass so the ivar-backed settings do not grow object shape variations on the shared `Node` class (which would degrade ivar access and trigger Ruby performance warnings). `deep_dup` reuses the template's subclass, so duplicated configs share object shapes.
+
 ## 2.6.0 (2026-06-10)
 - [Enhancement] Add `Node#register` to allow runtime key-value registration on compiled nodes without going through the static `setting` DSL. Useful for dynamic registries (e.g. named clusters) where setting names are not known at class-load time.
 - [Enhancement] Replace version-gated `Warning[:performance]` with a `Warning.categories`-based loop that enables all opt-in Ruby warning categories automatically, picking up new categories (e.g. `strict_unused_block` in Ruby 3.4+) without future patches.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 2.6.1 (2026-06-11)
 - [Enhancement] Mirror config values into instance variables and use `attr_reader` based readers in `Configurable::Node`, yielding ~1.4x faster flat and ~1.6x faster nested settings reads on hot paths. `@configs_refs` remains the canonical store; non-identifier setting names (e.g. registered names with dashes) keep the previous hash-based accessors.
 - [Enhancement] Instantiate each `Configurable::Node` through a per-layout anonymous subclass so the ivar-backed settings do not grow object shape variations on the shared `Node` class (which would degrade ivar access and trigger Ruby performance warnings). `deep_dup` reuses the template's subclass, so duplicated configs share object shapes.
+- [Fix] Symbolize setting names in the config store so `String` setting names work end to end and cannot corrupt node internal state when matching reserved internal names (previously string-named settings were quietly broken as accessors and the store disagreed on the key type).
+- [Change] Config nodes are now instances of anonymous `Node` subclasses: `is_a?(Karafka::Core::Configurable::Node)` still holds, but `instance_of?(Node)` is now `false` and `node.class.name` is `nil`.
+- [Change] Assigning a setting on a frozen config node now raises `FrozenError` (previously the write silently mutated internal storage despite the freeze).
 
 ## 2.6.0 (2026-06-10)
 - [Enhancement] Add `Node#register` to allow runtime key-value registration on compiled nodes without going through the static `setting` DSL. Useful for dynamic registries (e.g. named clusters) where setting names are not known at class-load time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.6.1 (2026-06-11)
 - [Enhancement] Mirror config values into instance variables and use `attr_reader` based readers in `Configurable::Node`, yielding ~1.4x faster flat and ~1.6x faster nested settings reads on hot paths. `@configs_refs` remains the canonical store; non-identifier setting names (e.g. registered names with dashes) keep the previous hash-based accessors.
 - [Enhancement] Instantiate each `Configurable::Node` through a per-layout anonymous subclass so the ivar-backed settings do not grow object shape variations on the shared `Node` class (which would degrade ivar access and trigger Ruby performance warnings). `deep_dup` reuses the template's subclass, so duplicated configs share object shapes.
-- [Fix] Symbolize setting names in the config store so `String` setting names work end to end and cannot corrupt node internal state when matching reserved internal names (previously string-named settings were quietly broken as accessors and the store disagreed on the key type).
+- [Fix] Symbolize setting names at definition time (`setting`, same as `register`) and on config store writes so `String` setting names work end to end (accessors, `#to_h`, recompilation state) and cannot corrupt node internal state when matching reserved internal names (previously string-named settings were quietly broken as accessors and the store disagreed on the key type).
 - [Change] Config nodes are now instances of anonymous `Node` subclasses: `is_a?(Karafka::Core::Configurable::Node)` still holds, but `instance_of?(Node)` is now `false` and `node.class.name` is `nil`.
 - [Change] Assigning a setting on a frozen config node now raises `FrozenError` (previously the write silently mutated internal storage despite the freeze).
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka-core (2.6.0)
+    karafka-core (2.6.1)
       karafka-rdkafka (>= 0.20.0)
       logger (>= 1.6.0)
 

--- a/lib/karafka/core/configurable/node.rb
+++ b/lib/karafka/core/configurable/node.rb
@@ -15,6 +15,36 @@ module Karafka
         # We need to be able to redefine children for deep copy
         attr_accessor :children
 
+        # Names of settings that cannot use the ivar-backed fast accessors because they would
+        # collide with the node internal state
+        RESERVED_NAMES = %i[
+          node_name
+          children
+          nestings
+          compiled
+          configs_refs
+          local_defs
+        ].to_h { |name| [name, true] }.freeze
+
+        # Setting names that match this format can be backed by instance variables and use the
+        # fast `attr_reader` based readers. Others (e.g. registered names with dashes) fall back
+        # to the hash-based accessors
+        IVAR_NAMEABLE_FORMAT = /\A[A-Za-z_][A-Za-z0-9_]*\z/
+
+        private_constant :RESERVED_NAMES, :IVAR_NAMEABLE_FORMAT
+
+        class << self
+          # Builds each node through its own anonymous subclass. Since setting values are
+          # mirrored into instance variables for fast access and each node layout carries a
+          # different set of them, instantiating nodes directly from this class would grow its
+          # object shape variations past the Ruby limit, degrading ivar access for all nodes.
+          # A subclass per layout keeps every class at a single shape. `#deep_dup` reuses the
+          # subclass of its template, so duplicated configs share shapes as well.
+          def new(...)
+            equal?(Node) ? Class.new(self).new(...) : super
+          end
+        end
+
         # @param node_name [Symbol] node name
         # @param nestings [Proc] block for nested settings
         # @param evaluate [Boolean] when false, skip evaluating the nestings block. Used by
@@ -85,7 +115,8 @@ module Karafka
         # and non-side-effect usage on an instance/inherited.
         # @return [Node] duplicated node
         def deep_dup
-          dupped = Node.new(node_name, nestings, evaluate: false)
+          # Same-layout nodes reuse the class of their template so they share object shapes
+          dupped = self.class.new(node_name, nestings, evaluate: false)
 
           children.each do |value|
             dupped.children << if value.is_a?(Leaf)
@@ -125,7 +156,7 @@ module Karafka
           leaf = Leaf.new(name, value, nil, true, false)
           @children << leaf
           build_accessors(leaf)
-          @configs_refs[name] = value
+          config_write(name, value)
         end
 
         # Converts the settings definitions into end children
@@ -161,7 +192,7 @@ module Karafka
             if lazy_leaf && !initialized
               build_dynamic_accessor(value)
             else
-              @configs_refs[value.node_name] = initialized
+              config_write(value.node_name, initialized)
             end
           end
 
@@ -207,6 +238,12 @@ module Karafka
 
         # Builds regular accessors for value fetching
         #
+        # Settings with names that can form valid instance variables get `attr_reader` based
+        # readers backed by an ivar mirror of the config value. This is significantly faster
+        # than a method with a hash lookup, which matters since settings are read on hot paths
+        # across the whole ecosystem. `@configs_refs` remains the canonical store used by
+        # `#to_h`, `#compile` and `#register`, with `#config_write` keeping the mirror in sync.
+        #
         # @param value [Leaf]
         def build_accessors(value)
           reader_name = value.node_name.to_sym
@@ -219,16 +256,45 @@ module Karafka
           if reader_respond ? !@local_defs.key?(reader_name) : true
             @local_defs[reader_name] = true
 
-            define_singleton_method(reader_name) do
-              @configs_refs[reader_name]
+            if ivar_backed?(reader_name)
+              singleton_class.attr_reader(reader_name)
+            else
+              define_singleton_method(reader_name) do
+                @configs_refs[reader_name]
+              end
             end
           end
 
-          return if respond_to?(:"#{value.node_name}=")
+          return if respond_to?(:"#{reader_name}=")
 
-          define_singleton_method(:"#{value.node_name}=") do |new_value|
-            @configs_refs[value.node_name] = new_value
+          if ivar_backed?(reader_name)
+            ivar_name = :"@#{reader_name}"
+
+            define_singleton_method(:"#{reader_name}=") do |new_value|
+              instance_variable_set(ivar_name, @configs_refs[reader_name] = new_value)
+            end
+          else
+            define_singleton_method(:"#{reader_name}=") do |new_value|
+              @configs_refs[reader_name] = new_value
+            end
           end
+        end
+
+        # Writes a config value to the canonical store and mirrors it into the backing instance
+        # variable when the setting uses the fast ivar-backed reader
+        #
+        # @param name [Symbol] setting name
+        # @param value [Object] config value assigned to the setting
+        def config_write(name, value)
+          @configs_refs[name] = value
+          instance_variable_set(:"@#{name}", value) if ivar_backed?(name)
+        end
+
+        # @param name [Symbol] setting name
+        # @return [Boolean] true if this setting can be backed by an instance variable and use
+        #   the fast `attr_reader` based reader
+        def ivar_backed?(name)
+          !RESERVED_NAMES.key?(name) && IVAR_NAMEABLE_FORMAT.match?(name)
         end
       end
     end

--- a/lib/karafka/core/configurable/node.rb
+++ b/lib/karafka/core/configurable/node.rb
@@ -63,12 +63,17 @@ module Karafka
 
         # Allows for a single leaf or nested node definition
         #
-        # @param node_name [Symbol] setting or nested node name
+        # @param node_name [Symbol, String] setting or nested node name
         # @param default [Object] default value
         # @param constructor [#call, nil] callable or nil
         # @param lazy [Boolean] is this a lazy leaf
         # @param block [Proc] block for nested settings
         def setting(node_name, default: nil, constructor: nil, lazy: false, &block)
+          # Symbolize at definition time (same as `#register`) so the config store, accessors,
+          # `#to_h` and the compile state checks all agree on the key type also when a String
+          # name is provided
+          node_name = node_name.to_sym
+
           @children << if block
             Node.new(node_name, block)
           else

--- a/lib/karafka/core/configurable/node.rb
+++ b/lib/karafka/core/configurable/node.rb
@@ -38,8 +38,10 @@ module Karafka
           # mirrored into instance variables for fast access and each node layout carries a
           # different set of them, instantiating nodes directly from this class would grow its
           # object shape variations past the Ruby limit, degrading ivar access for all nodes.
-          # A subclass per layout keeps every class at a single shape. `#deep_dup` reuses the
-          # subclass of its template, so duplicated configs share shapes as well.
+          # A subclass per layout keeps shape variations per class minimal (late `setting`
+          # calls after inheritance or runtime `register` calls may add a few more, staying
+          # well under the limit). `#deep_dup` reuses the subclass of its template, so
+          # duplicated configs share shapes as well.
           def new(...)
             equal?(Node) ? Class.new(self).new(...) : super
           end
@@ -283,9 +285,14 @@ module Karafka
         # Writes a config value to the canonical store and mirrors it into the backing instance
         # variable when the setting uses the fast ivar-backed reader
         #
-        # @param name [Symbol] setting name
+        # @param name [Symbol, String] setting name
         # @param value [Object] config value assigned to the setting
         def config_write(name, value)
+          # Accessors operate on symbolized names, so the store has to be keyed consistently.
+          # This also guarantees that a String name matching a reserved internal name is
+          # recognized by the `ivar_backed?` guard and cannot corrupt the node internal state
+          name = name.to_sym
+
           @configs_refs[name] = value
           instance_variable_set(:"@#{name}", value) if ivar_backed?(name)
         end

--- a/lib/karafka/core/version.rb
+++ b/lib/karafka/core/version.rb
@@ -4,6 +4,6 @@ module Karafka
   module Core
     # Current Karafka::Core version
     # We follow the versioning schema of given Karafka version
-    VERSION = "2.6.0"
+    VERSION = "2.6.1"
   end
 end

--- a/test/lib/karafka/core/configurable_test.rb
+++ b/test/lib/karafka/core/configurable_test.rb
@@ -152,6 +152,28 @@ describe_current do
       end
     end
 
+    context "when a setting name is a string matching a reserved internal name" do
+      subject(:reserved_class) do
+        Class.new do
+          extend Karafka::Core::Configurable
+
+          setting("children", default: "boom")
+          setting(:regular, default: 1)
+        end
+      end
+
+      let(:reserved_config) { reserved_class.config }
+
+      it "does not corrupt the node internal state" do
+        assert_equal 1, reserved_config.regular
+        assert reserved_config.to_h.key?(:regular)
+      end
+
+      it "makes the value readable via accessor" do
+        assert_equal "boom", reserved_config.public_send(:children)
+      end
+    end
+
     context "when we do not override any settings" do
       before { configurable_class.configure }
 

--- a/test/lib/karafka/core/configurable_test.rb
+++ b/test/lib/karafka/core/configurable_test.rb
@@ -114,6 +114,31 @@ describe_current do
         end
       end
 
+      context "when registering a name that cannot back an instance variable" do
+        before { node.register(:"my-cluster", "dashed:9092") }
+
+        it "makes the value readable via accessor" do
+          assert_equal "dashed:9092", node.public_send(:"my-cluster")
+        end
+
+        it "makes the value writable via accessor" do
+          node.public_send(:"my-cluster=", "changed:9092")
+
+          assert_equal "changed:9092", node.public_send(:"my-cluster")
+        end
+
+        it "includes the registered key in to_h" do
+          assert_equal "dashed:9092", node.to_h[:"my-cluster"]
+        end
+
+        it "carries the registered key through deep_dup" do
+          dupped = node.deep_dup
+          dupped.configure
+
+          assert_equal "dashed:9092", dupped.public_send(:"my-cluster")
+        end
+      end
+
       context "when registering on a nested node" do
         before { configurable_class.config.nested1.register(:extra, "nested-value") }
 

--- a/test/lib/karafka/core/configurable_test.rb
+++ b/test/lib/karafka/core/configurable_test.rb
@@ -172,6 +172,38 @@ describe_current do
       it "makes the value readable via accessor" do
         assert_equal "boom", reserved_config.public_send(:children)
       end
+
+      it "exposes the value in to_h under a symbol key" do
+        assert_equal "boom", reserved_config.to_h[:children]
+      end
+    end
+
+    context "when a setting name is a string" do
+      subject(:string_named_class) do
+        Class.new do
+          extend Karafka::Core::Configurable
+
+          setting("alpha", default: 1)
+        end
+      end
+
+      let(:string_named_config) { string_named_class.config }
+
+      before { string_named_config.alpha = 5 }
+
+      it "reflects writes in the accessor" do
+        assert_equal 5, string_named_config.alpha
+      end
+
+      it "reflects writes in to_h under a symbol key" do
+        assert_equal 5, string_named_config.to_h[:alpha]
+      end
+
+      it "preserves the written value across reconfiguration" do
+        string_named_class.configure
+
+        assert_equal 5, string_named_config.alpha
+      end
     end
 
     context "when we do not override any settings" do


### PR DESCRIPTION
Settings are read on hot paths across the whole Karafka ecosystem, so the cost of each read matters. This replaces the define_singleton_method closures with hash lookups by attr_reader based readers backed by an instance variable mirror of the config value, yielding ~1.4x faster flat and ~1.6x faster nested settings reads (77ns -> 53ns and 129ns -> 79ns for 3-level chains on Ruby 3.4).

@configs_refs remains the canonical store used by #to_h, #compile and \#register, kept in sync via #config_write. Setting names that cannot form valid instance variables (e.g. registered names with dashes) and names colliding with the node internal state keep the previous hash-based accessors.

Since each node layout carries a different set of mirrored ivars, instantiating nodes directly from the shared Node class would grow its object shape variations past the Ruby limit, degrading ivar access for all nodes and triggering Ruby performance warnings. Node.new now builds each node through a per-layout anonymous subclass so every class keeps a single shape, and #deep_dup reuses the template subclass so duplicated configs (e.g. per-producer WaterDrop configs) share object shapes. Verified zero shape warnings booting Karafka + 15 WaterDrop producers with Warning[:performance] enabled.

Config writes get slightly slower due to the dual write, which is acceptable as writes happen at configuration time only.