### PR TITLE
Skip event name mapping in Monitor#instrument when no namespace is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka Core Changelog
 
 ## 2.6.1 (2026-06-11)
+- [Enhancement] Skip the event name mapping hash lookup in `Monitor#instrument` when no namespace is used and the event id is already a `String`, which is the case for all events in the Karafka ecosystem (~1.2x faster dispatch on the common no-subscribers path). Symbol event ids and namespaced monitors keep going through the mapping.
 - [Enhancement] Mirror config values into instance variables and use `attr_reader` based readers in `Configurable::Node`, yielding ~1.4x faster flat and ~1.6x faster nested settings reads on hot paths. `@configs_refs` remains the canonical store; non-identifier setting names (e.g. registered names with dashes) keep the previous hash-based accessors.
 - [Enhancement] Instantiate each `Configurable::Node` through a per-layout anonymous subclass so the ivar-backed settings do not grow object shape variations on the shared `Node` class (which would degrade ivar access and trigger Ruby performance warnings). `deep_dup` reuses the template's subclass, so duplicated configs share object shapes.
 - [Fix] Symbolize setting names at definition time (`setting`, same as `register`) and on config store writes so `String` setting names work end to end (accessors, `#to_h`, recompilation state) and cannot corrupt node internal state when matching reserved internal names (previously string-named settings were quietly broken as accessors and the store disagreed on the key type).

--- a/lib/karafka/core/monitoring/monitor.rb
+++ b/lib/karafka/core/monitoring/monitor.rb
@@ -28,7 +28,15 @@ module Karafka
         # @param event_id [String, Symbol] event id
         # @param payload [Hash]
         def instrument(event_id, payload = EMPTY_HASH, &)
-          full_event_name = @mapped_events[event_id] ||= [event_id, @namespace].compact.join(".")
+          # With no namespace, string event ids already are the full event names. This is the
+          # case for all the events in the Karafka ecosystem, so we can skip the mapping hash
+          # lookup on this hot path. Symbols still go through the mapping to be converted into
+          # strings without allocating on each call.
+          full_event_name = if @namespace.nil? && event_id.is_a?(String)
+            event_id
+          else
+            @mapped_events[event_id] ||= [event_id, @namespace].compact.join(".")
+          end
 
           @notifications_bus.instrument(full_event_name, payload, &)
         end

--- a/test/lib/karafka/core/monitoring/monitor_test.rb
+++ b/test/lib/karafka/core/monitoring/monitor_test.rb
@@ -35,6 +35,24 @@ describe_current do
     it { assert_kind_of Array, monitor.listeners["test"] }
   end
 
+  context "when we do not use any namespace and instrument with a symbol id" do
+    let(:namespace) { nil }
+    let(:collected_data) { [] }
+
+    before do
+      collected = collected_data
+
+      monitor.subscribe("test") do |event|
+        collected << event
+      end
+
+      monitor.instrument(:test) { 1 }
+    end
+
+    it { assert_equal 1, collected_data.size }
+    it { assert_equal "test", collected_data.first.id }
+  end
+
   context "when we do use a namespace" do
     let(:namespace) { "namespace" }
     let(:collected_data) { [] }


### PR DESCRIPTION
With no namespace, a String event id already is the full event name, so the @mapped_events hash lookup on every instrument call is pure overhead. This is the case for all events in the Karafka ecosystem (karafka and WaterDrop both use a nil namespace with String event ids), including the dominant path where instrumented events have no subscribers.

Benchmarked at ~1.1-1.2x faster dispatch on the no-subscribers path (242ns -> 217ns per call on Ruby 3.4).

Symbol event ids keep going through the mapping so they are converted to registered String names without allocating on each call (Symbol#to_s allocates), covered with a new test. Namespaced monitors are unaffected.