### PR TITLE
Make frozen config node setting assignment atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka Core Changelog
 
+## 2.6.2 (Unreleased)
+- [Fix] Make assigning a setting on a frozen `Configurable::Node` atomic. The ivar-backed writer evaluated `@configs_refs[name] = value` before `instance_variable_set`, so a frozen node mutated the canonical store and only then raised `FrozenError`, leaving the store and the ivar-backed reader permanently out of sync. It now raises before touching any state.
+
 ## 2.6.1 (2026-06-15)
 - [Enhancement] Speed up `Contract#call` by ~1.25x for minimal and ~1.4x for fully populated data: resolve rule paths with a single `Hash#fetch` per level instead of `key?` + `[]`, inline the per-rule type dispatch into the rules loop, and compare the dig sentinel via `#equal?` so `#==` is never dispatched to the validated (user-provided) values. This is the per-message validation path in WaterDrop producers.
 - [Fix] `Contract#call` with rule paths of 3+ keys no longer raises `NoMethodError` when an intermediate value is not a `Hash` and reports the path as missing instead, consistent with the 2-key path behavior.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka-core (2.6.1)
+    karafka-core (2.6.2)
       karafka-rdkafka (>= 0.20.0)
       logger (>= 1.6.0)
 

--- a/lib/karafka/core/configurable/node.rb
+++ b/lib/karafka/core/configurable/node.rb
@@ -295,7 +295,12 @@ module Karafka
             ivar_name = :"@#{reader_name}"
 
             define_singleton_method(:"#{reader_name}=") do |new_value|
-              instance_variable_set(ivar_name, @configs_refs[reader_name] = new_value)
+              # Assign the ivar first: on a frozen node this raises FrozenError before the
+              # canonical store is touched. Writing the store first (as part of the same
+              # expression) mutated `@configs_refs` and only then raised, leaving the store and
+              # the ivar-backed reader permanently out of sync.
+              instance_variable_set(ivar_name, new_value)
+              @configs_refs[reader_name] = new_value
             end
           else
             define_singleton_method(:"#{reader_name}=") do |new_value|

--- a/lib/karafka/core/configurable/node.rb
+++ b/lib/karafka/core/configurable/node.rb
@@ -295,10 +295,6 @@ module Karafka
             ivar_name = :"@#{reader_name}"
 
             define_singleton_method(:"#{reader_name}=") do |new_value|
-              # Assign the ivar first: on a frozen node this raises FrozenError before the
-              # canonical store is touched. Writing the store first (as part of the same
-              # expression) mutated `@configs_refs` and only then raised, leaving the store and
-              # the ivar-backed reader permanently out of sync.
               instance_variable_set(ivar_name, new_value)
               @configs_refs[reader_name] = new_value
             end

--- a/lib/karafka/core/version.rb
+++ b/lib/karafka/core/version.rb
@@ -4,6 +4,6 @@ module Karafka
   module Core
     # Current Karafka::Core version
     # We follow the versioning schema of given Karafka version
-    VERSION = "2.6.1"
+    VERSION = "2.6.2"
   end
 end

--- a/test/lib/karafka/core/configurable_test.rb
+++ b/test/lib/karafka/core/configurable_test.rb
@@ -702,4 +702,37 @@ describe_current do
       assert_equal 123, config.logger
     end
   end
+
+  context "when assigning a setting on a frozen config node" do
+    # Regression: the ivar-backed writer evaluated `@configs_refs[name] = value` before
+    # `instance_variable_set`, so a frozen node mutated the canonical store and only then raised
+    # FrozenError, leaving the store and the ivar-backed reader out of sync. The write must be
+    # atomic: it raises without changing any state.
+    let(:configurable_class) do
+      Class.new do
+        include Karafka::Core::Configurable
+
+        setting(:a, default: 1)
+      end
+    end
+
+    let(:config) { configurable_class.new.tap(&:configure).config }
+
+    before { config.freeze }
+
+    it "raises FrozenError" do
+      assert_raises(FrozenError) { config.a = 5 }
+    end
+
+    it "does not mutate the store or the reader when the write is rejected" do
+      begin
+        config.a = 5
+      rescue FrozenError
+        nil
+      end
+
+      assert_equal 1, config.a
+      assert_equal 1, config.to_h[:a]
+    end
+  end
 end


### PR DESCRIPTION
The ivar-backed writer was `instance_variable_set(ivar, @configs_refs[name] = value)`. The inner assignment to @configs_refs is evaluated first, so on a frozen node the canonical store was mutated and only then did instance_variable_set raise FrozenError. The store and the ivar-backed reader were left permanently out of sync: the reader returned the old value while #to_h (which reads @configs_refs) returned the new one.

Assign the ivar first so FrozenError is raised before the store is touched, making a rejected write leave all state unchanged.

Adds a regression test asserting a rejected frozen write changes neither the reader nor #to_h.