### PR TITLE
Fix SimpleCov add_filter deprecation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,6 @@ GEM
   specs:
     byebug (13.0.0)
       reline (>= 0.6.0)
-    docile (1.4.1)
     drb (2.2.3)
     ffi (1.17.4)
     ffi (1.17.4-aarch64-linux-gnu)
@@ -70,12 +69,7 @@ GEM
     rake (13.4.2)
     reline (0.6.3)
       io-console (~> 0.5)
-    simplecov (0.22.0)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.13.2)
-    simplecov_json_formatter (0.1.4)
+    simplecov (1.0.0)
     warning (1.6.0)
 
 PLATFORMS

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,13 +33,13 @@ end
 
 # Don't include unnecessary stuff into rcov
 SimpleCov.start do
-  add_filter "/vendor/"
-  add_filter "/gems/"
-  add_filter "/.bundle/"
-  add_filter "/doc/"
-  add_filter "/test/"
-  add_filter "/config/"
-  add_filter "/patches/"
+  skip "/vendor/"
+  skip "/gems/"
+  skip "/.bundle/"
+  skip "/doc/"
+  skip "/test/"
+  skip "/config/"
+  skip "/patches/"
   merge_timeout 600
 end
 


### PR DESCRIPTION
SimpleCov 1.0.0 renames add_filter to skip (same arguments and behavior) and deprecates the old name. Our test helper promotes warnings to errors, so the suite would break as soon as simplecov resolves to 1.0.0.

Rename all add_filter calls in test/test_helper.rb to skip and bump the locked simplecov to 1.0.0, since skip only exists in simplecov >= 1.0.0. simplecov 1.0.0 has no runtime dependencies, so docile, simplecov-html and simplecov_json_formatter drop out of the lockfile.